### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-vue-storefront-cloud.yml
+++ b/.github/workflows/deploy-vue-storefront-cloud.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "12.x"
       - name: Build and publish docker image
-        # uses: elgohr/Publish-Docker-Github-Action@master
+        # uses: elgohr/Publish-Docker-Github-Action@v5
         # 3.04 is hardcoded as a workaround for https://github.com/elgohr/Publish-Docker-Github-Action/issues/134
         uses: elgohr/Publish-Docker-Github-Action@3.04
         with:

--- a/.github/workflows/docs-deployment.yaml
+++ b/.github/workflows/docs-deployment.yaml
@@ -20,7 +20,7 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::$(cat version.txt)
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docs-storefrontcloud-io/v2-vendure:${{ steps.get_version.outputs.VERSION }}
           registry: registry.storefrontcloud.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore